### PR TITLE
Fixed #1

### DIFF
--- a/WindowsIsoDownloader.csproj
+++ b/WindowsIsoDownloader.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Playwright" Version="1.31.1" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.37.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/config.json
+++ b/config.json
@@ -30,7 +30,7 @@
 			"WaitBeforeAction": 2500,
 			"Parameters": {
 				"Selector": "#product-languages",
-				"Values": "{\"id\":\"16029\",\"language\":\"English\"}"
+				"Values": "English (United States)"
 			}
 		},
 		{

--- a/config.json
+++ b/config.json
@@ -14,7 +14,7 @@
 			"Kind": "SelectOption",
 			"Parameters": {
 				"Selector": "#product-edition",
-				"Values": "2616"
+				"Values": "Windows 11 (multi-edition ISO for x64 devices)"
 			}
 		},
 		{


### PR DESCRIPTION
Edit:
implements the option to specify the language by running ".\WindowsIsoDownloader.exe German" for german iso or ".\WindowsIsoDownloader.exe French" for french language. All other languages are supported as of the selection menu on the download page here https://www.microsoft.com/en-us/software-download/windows11/